### PR TITLE
aligned time rule and fix candle update timing on agg trigger

### DIFF
--- a/src/aggregation_rules/aligned_time_rule.rs
+++ b/src/aggregation_rules/aligned_time_rule.rs
@@ -1,0 +1,115 @@
+use crate::aggregation_rules::TimestampResolution;
+use crate::{AggregationRule, ModularCandle, TakerTrade};
+
+/// The classic time based aggregation rule,
+/// creating a new candle every n seconds.  The time trigger is aligned such that
+/// the trigger points are starting from a time equals zero.  For example, if the first
+/// tick comes in a 1:32:00 on a 5 minute candle, that first candle will only contain
+/// 3 minutes of trades, representing a 1:30 start.
+pub struct AlignedTimeRule {
+    /// If true, the reference timestamp needs to be reset
+    init: bool,
+
+    // The timestamp this rule uses as a reference
+    reference_timestamp: i64,
+
+    // The period for the candle in seconds
+    // constants can be used nicely here from constants.rs
+    // e.g.: M1 -> 1 minute candles
+    period_s: i64,
+}
+
+impl AlignedTimeRule {
+    /// Create a new instance of the aligned time rule,
+    /// with a given candle period in seconds
+    ///
+    /// # Arguments:
+    /// period_s: How many seconds a candle will contain
+    /// ts_res: The resolution each Trade timestamp will have
+    ///
+    pub fn new(period_s: i64, ts_res: TimestampResolution) -> Self {
+        let ts_multiplier = match ts_res {
+            TimestampResolution::Second => 1,
+            TimestampResolution::Millisecond => 1_000,
+            TimestampResolution::Microsecond => 1_000_000,
+            TimestampResolution::Nanosecond => 1_000_000_000,
+        };
+
+        Self {
+            init: true,
+            reference_timestamp: 0,
+            period_s: period_s * ts_multiplier,
+        }
+    }
+
+    /// Calculates the "aligned" timestamp, which the rule will use when receiving
+    /// for determining the trigger.  This is done at the initialization of
+    /// each period.
+    #[must_use]
+    pub fn aligned_timestamp(&self, timestamp: i64) -> i64 {
+        timestamp - (timestamp % self.period_s)
+    }
+}
+
+impl<C, T> AggregationRule<C, T> for AlignedTimeRule
+where
+    C: ModularCandle<T>,
+    T: TakerTrade,
+{
+    fn should_trigger(&mut self, trade: &T, _candle: &C) -> bool {
+        if self.init {
+            self.reference_timestamp = self.aligned_timestamp(trade.timestamp());
+            self.init = false;
+        }
+        let should_trigger = trade.timestamp() - self.reference_timestamp > self.period_s;
+        if should_trigger {
+            self.init = true;
+        }
+
+        should_trigger
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        aggregate_all_trades,
+        candle_components::{
+            CandleComponent, CandleComponentUpdate, Close, High, Low, Open,
+        },
+        load_trades_from_csv,
+        GenericAggregator, ModularCandle, Trade, M15,
+    };
+    use trade_aggregation_derive::Candle;
+
+    use super::*;
+
+    #[test]
+    fn aligned_time_rule() {
+        #[derive(Debug, Default, Clone, Candle)]
+        struct AlignedCandle {
+            pub open: Open,
+            high: High,
+            low: Low,
+            pub close: Close,
+        }
+
+        let trades = load_trades_from_csv("data/Bitmex_XBTUSD_1M.csv").unwrap();
+
+        let mut aggregator =
+            GenericAggregator::<AlignedCandle, AlignedTimeRule, Trade>::new(
+                AlignedTimeRule::new(M15, TimestampResolution::Millisecond),
+            );
+        let candles = aggregate_all_trades(&trades, &mut aggregator);
+        assert_eq!(candles.len(), 396);
+
+        // make sure that the aggregator starts a new candle with the "trigger tick"
+        // rather than updating the existing candle with the "trigger tick"
+        let c = &candles[0];
+        assert_eq!(c.open.value(), 13873.0);
+        assert_eq!(c.close.value(), 13769.0);
+        let c = &candles[1];
+        assert_eq!(c.open.value(), 13768.5);
+        assert_eq!(c.close.value(), 13721.5);
+    }
+}

--- a/src/aggregation_rules/mod.rs
+++ b/src/aggregation_rules/mod.rs
@@ -1,7 +1,9 @@
 mod aggregation_rule_trait;
+mod aligned_time_rule;
 mod time_rule;
 mod volume_rule;
 
 pub use aggregation_rule_trait::AggregationRule;
+pub use aligned_time_rule::*;
 pub use time_rule::*;
 pub use volume_rule::VolumeRule;

--- a/src/aggregation_rules/time_rule.rs
+++ b/src/aggregation_rules/time_rule.rs
@@ -77,10 +77,12 @@ where
 #[cfg(test)]
 mod tests {
     use crate::{
-        aggregate_all_trades, load_trades_from_csv,
+        aggregate_all_trades,
+        load_trades_from_csv,
         plot::{plot_ohlc_candles, OhlcCandle},
         GenericAggregator, Trade, H1, M15, M5,
     };
+    
 
     use super::*;
 
@@ -88,38 +90,33 @@ mod tests {
     fn time_candles_plot() {
         let trades = load_trades_from_csv("data/Bitmex_XBTUSD_1M.csv").unwrap();
 
-        let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(TimeRule::new(
-            M15,
-            TimestampResolution::Millisecond,
-        ));
+        let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(
+            TimeRule::new(M15, TimestampResolution::Millisecond),
+        );
         let candles = aggregate_all_trades(&trades, &mut aggregator);
         println!("got {} candles", candles.len());
 
         plot_ohlc_candles(&candles, "img/time_candles_plot.png", (2560, 1440)).unwrap();
     }
-
     #[test]
     fn time_rule_differing_periods() {
         let trades = load_trades_from_csv("data/Bitmex_XBTUSD_1M.csv").unwrap();
 
-        let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(TimeRule::new(
-            M15,
-            TimestampResolution::Millisecond,
-        ));
+        let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(
+            TimeRule::new(M15, TimestampResolution::Millisecond),
+        );
         let candles = aggregate_all_trades(&trades, &mut aggregator);
         assert_eq!(candles.len(), 395);
 
-        let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(TimeRule::new(
-            M5,
-            TimestampResolution::Millisecond,
-        ));
+        let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(
+            TimeRule::new(M5, TimestampResolution::Millisecond),
+        );
         let candles = aggregate_all_trades(&trades, &mut aggregator);
         assert_eq!(candles.len(), 1180);
 
-        let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(TimeRule::new(
-            H1,
-            TimestampResolution::Millisecond,
-        ));
+        let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(
+            TimeRule::new(H1, TimestampResolution::Millisecond),
+        );
         let candles = aggregate_all_trades(&trades, &mut aggregator);
         assert_eq!(candles.len(), 99);
     }
@@ -156,31 +153,27 @@ mod tests {
             .collect();
 
         // And make sure they produce the same number of candles regardless of timestamp resolution
-        let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(TimeRule::new(
-            M15,
-            TimestampResolution::Second,
-        ));
+        let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(
+            TimeRule::new(M15, TimestampResolution::Second),
+        );
         let candles = aggregate_all_trades(&trades_s, &mut aggregator);
         assert_eq!(candles.len(), 395);
 
-        let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(TimeRule::new(
-            M15,
-            TimestampResolution::Millisecond,
-        ));
+        let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(
+            TimeRule::new(M15, TimestampResolution::Millisecond),
+        );
         let candles = aggregate_all_trades(&trades_ms, &mut aggregator);
         assert_eq!(candles.len(), 395);
 
-        let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(TimeRule::new(
-            M15,
-            TimestampResolution::Microsecond,
-        ));
+        let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(
+            TimeRule::new(M15, TimestampResolution::Microsecond),
+        );
         let candles = aggregate_all_trades(&trades_micros, &mut aggregator);
         assert_eq!(candles.len(), 395);
 
-        let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(TimeRule::new(
-            M15,
-            TimestampResolution::Nanosecond,
-        ));
+        let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(
+            TimeRule::new(M15, TimestampResolution::Nanosecond),
+        );
         let candles = aggregate_all_trades(&trades_ns, &mut aggregator);
         assert_eq!(candles.len(), 395);
     }

--- a/src/aggregator.rs
+++ b/src/aggregator.rs
@@ -49,14 +49,13 @@ where
     T: TakerTrade,
 {
     fn update(&mut self, trade: &T) -> Option<C> {
-        self.candle.update(trade);
-
         if self.aggregation_rule.should_trigger(trade, &self.candle) {
             let candle = self.candle.clone();
             self.candle.reset();
-
+            self.candle.update(trade);
             Some(candle)
         } else {
+            self.candle.update(trade);
             None
         }
     }
@@ -89,7 +88,11 @@ mod tests {
         let mut candle_counter: usize = 0;
         for t in trades.iter() {
             if let Some(candle) = a.update(t) {
-                // println!("got candle: {:?}", candle);
+                // println!(
+                //     "got candle: {:?} at {:?}, {:?}",
+                //     candle, t.timestamp, t.price
+                // );
+
                 candle_counter += 1;
             }
         }


### PR DESCRIPTION
@MathisWellmann: here is a new "rule" for aligning the OHLC bars on standard time intervals. 

Also noticed that the on the aggregator trigger the emitted candle was getting the update from the tick that crossed the trigger threshold.  I believe this should actually be the new candle getting this update.  My `aligned_time_rule` test has a couple asserts regarding this, for which the fix was a slight reordering of the aggregator code.

Let me know what you think when you get a chance.  

I am also wanting to add a time candle component but may do that in a separate PR.

Cheers!
Dave 