### PR TITLE
Date component

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ trade_aggregation_derive = {path = "./trade_aggregation_derive"}
 
 # Optionals
 serde = { version = "^1", features = ["derive"], optional = true }
+chrono = { version = "0.4", optional = true }
 
 [dev-dependencies]
 round = "^0.1"
@@ -32,3 +33,4 @@ harness = false
 
 [features]
 serde = ["dep:serde"]
+chrono = ["dep:chrono"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ trade_aggregation_derive = {path = "./trade_aggregation_derive"}
 
 # Optionals
 serde = { version = "^1", features = ["derive"], optional = true }
-chrono = { version = "0.4", optional = true }
+chrono = { version = "0.4", features = ["serde"], optional = true }
 
 [dev-dependencies]
 round = "^0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ exclude = ["/img", "/.idea"]
 csv = "^1"
 thiserror = "^1"
 
-trade_aggregation_derive = "0.3.2"
+# trade_aggregation_derive = "0.3.2"
+trade_aggregation_derive = {path = "./trade_aggregation_derive"}
 
 # Optionals
 serde = { version = "^1", features = ["derive"], optional = true }

--- a/benches/candle_aggregation.rs
+++ b/benches/candle_aggregation.rs
@@ -25,7 +25,7 @@ struct CandleAll {
     low: Low,
     close: Close,
     volume: Volume,
-    num_trades: NumTrades,
+    num_trades: NumTrades<u32>,
     directional_trade_ratio: DirectionalTradeRatio,
     directional_volume_ratio: DirectionalVolumeRatio,
     std_dev_prices: StdDevPrices,

--- a/src/aggregator.rs
+++ b/src/aggregator.rs
@@ -73,7 +73,7 @@ mod tests {
 
     use super::*;
     use crate::{
-        candle_components::{CandleComponent, CandleComponentUpdate, Close, Open},
+        candle_components::{CandleComponent, CandleComponentUpdate, Close, NumTrades, Open},
         load_trades_from_csv, ModularCandle, TimeRule, TimestampResolution, Trade, M1,
     };
 
@@ -81,6 +81,7 @@ mod tests {
     struct MyCandle {
         open: Open,
         close: Close,
+        num_trades: NumTrades<u32>,
     }
 
     #[test]

--- a/src/candle_components/average_price.rs
+++ b/src/candle_components/average_price.rs
@@ -8,8 +8,7 @@ pub struct AveragePrice {
     price_sum: f64,
 }
 
-impl CandleComponent for AveragePrice {
-    type Output = f64;
+impl CandleComponent<f64> for AveragePrice {
     #[inline(always)]
     fn value(&self) -> f64 {
         self.price_sum / self.num_trades

--- a/src/candle_components/average_price.rs
+++ b/src/candle_components/average_price.rs
@@ -9,6 +9,7 @@ pub struct AveragePrice {
 }
 
 impl CandleComponent for AveragePrice {
+    type Output = f64;
     #[inline(always)]
     fn value(&self) -> f64 {
         self.price_sum / self.num_trades

--- a/src/candle_components/candle_component_trait.rs
+++ b/src/candle_components/candle_component_trait.rs
@@ -2,9 +2,11 @@ use crate::TakerTrade;
 
 /// Each component of a Candle must fullfill this trait
 pub trait CandleComponent {
+    /// An associated type which is the output type of the value() method
+    type Output;
     /// The current value of the component
     // TODO: make output type generic
-    fn value(&self) -> f64;
+    fn value(&self) -> Self::Output;
 
     /// Resets the component state to its default
     fn reset(&mut self);

--- a/src/candle_components/candle_component_trait.rs
+++ b/src/candle_components/candle_component_trait.rs
@@ -1,12 +1,10 @@
 use crate::TakerTrade;
 
 /// Each component of a Candle must fullfill this trait
-pub trait CandleComponent {
+pub trait CandleComponent<T> {
     /// An associated type which is the output type of the value() method
-    type Output;
     /// The current value of the component
-    // TODO: make output type generic
-    fn value(&self) -> Self::Output;
+    fn value(&self) -> T;
 
     /// Resets the component state to its default
     fn reset(&mut self);

--- a/src/candle_components/candle_datetime.rs
+++ b/src/candle_components/candle_datetime.rs
@@ -1,17 +1,17 @@
-use crate::{CandleComponent, CandleComponentUpdate, TakerTrade};
+#![cfg(feature = "chrono")]
+use chrono::{DateTime, Utc};
 
-/// This 'CandleComponent' keeps track of the opening timestamp of a Candle
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct TimeStamp<T> {
+pub struct CandleDateTime {
     init: bool,
-    value: T,
+    value: DateTime<Utc>,
 }
 
-impl CandleComponent<i64> for TimeStamp<i64> {
+impl CandleComponent<DateTime<Utc>> for CandleDateTime {
     /// Returns the open price of the candle
     #[inline(always)]
-    fn value(&self) -> i64 {
+    fn value(&self) -> DateTime<Utc> {
         self.value
     }
     /// This makes sure the next time "update" is called, the new open value is set
@@ -21,12 +21,12 @@ impl CandleComponent<i64> for TimeStamp<i64> {
     }
 }
 
-impl<T: TakerTrade> CandleComponentUpdate<T> for TimeStamp<i64> {
+impl<T: TakerTrade> CandleComponentUpdate<T> for CandleDateTime {
     /// Only update the open price if this module is in init mode
     #[inline(always)]
     fn update(&mut self, trade: &T) {
         if self.init {
-            self.value = trade.timestamp();
+            self.value = Utc.timestamp_millis(trade.timestamp(), 0);
             self.init = false;
         }
     }

--- a/src/candle_components/close.rs
+++ b/src/candle_components/close.rs
@@ -7,8 +7,7 @@ pub struct Close {
     value: f64,
 }
 
-impl CandleComponent for Close {
-    type Output = f64;
+impl CandleComponent<f64> for Close {
     #[inline(always)]
     fn value(&self) -> f64 {
         self.value

--- a/src/candle_components/close.rs
+++ b/src/candle_components/close.rs
@@ -8,6 +8,7 @@ pub struct Close {
 }
 
 impl CandleComponent for Close {
+    type Output = f64;
     #[inline(always)]
     fn value(&self) -> f64 {
         self.value

--- a/src/candle_components/date.rs
+++ b/src/candle_components/date.rs
@@ -3,25 +3,16 @@ use crate::{CandleComponent, CandleComponentUpdate, TakerTrade};
 /// This 'CandleComponent' keeps track of the opening price of a Candle
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Open {
+pub struct TimeStamp {
     init: bool,
-    value: f64,
+    value: i64,
 }
 
-impl Default for Open {
-    fn default() -> Self {
-        Self {
-            init: true,
-            value: 0.0,
-        }
-    }
-}
-
-impl CandleComponent for Open {
-    type Output = f64;
+impl CandleComponent for TimeStamp {
+    type Output = i64;
     /// Returns the open price of the candle
     #[inline(always)]
-    fn value(&self) -> f64 {
+    fn value(&self) -> i64 {
         self.value
     }
     /// This makes sure the next time "update" is called, the new open value is set
@@ -31,28 +22,13 @@ impl CandleComponent for Open {
     }
 }
 
-impl<T: TakerTrade> CandleComponentUpdate<T> for Open {
+impl<T: TakerTrade> CandleComponentUpdate<T> for TimeStamp {
     /// Only update the open price if this module is in init mode
     #[inline(always)]
     fn update(&mut self, trade: &T) {
         if self.init {
-            self.value = trade.price();
+            self.value = trade.timestamp();
             self.init = false;
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn open() {
-        let mut m = Open::default();
-        let first_trade = &crate::candle_components::tests::TRADES[0];
-        for t in &crate::candle_components::tests::TRADES {
-            m.update(t);
-            assert_eq!(m.value(), first_trade.price());
         }
     }
 }

--- a/src/candle_components/directional_trade_ratio.rs
+++ b/src/candle_components/directional_trade_ratio.rs
@@ -9,6 +9,7 @@ pub struct DirectionalTradeRatio {
 }
 
 impl CandleComponent for DirectionalTradeRatio {
+    type Output = f64;
     #[inline(always)]
     fn value(&self) -> f64 {
         self.num_buys as f64 / self.num_trades as f64

--- a/src/candle_components/directional_trade_ratio.rs
+++ b/src/candle_components/directional_trade_ratio.rs
@@ -8,8 +8,7 @@ pub struct DirectionalTradeRatio {
     num_trades: usize,
 }
 
-impl CandleComponent for DirectionalTradeRatio {
-    type Output = f64;
+impl CandleComponent<f64> for DirectionalTradeRatio {
     #[inline(always)]
     fn value(&self) -> f64 {
         self.num_buys as f64 / self.num_trades as f64

--- a/src/candle_components/directional_volume_ratio.rs
+++ b/src/candle_components/directional_volume_ratio.rs
@@ -8,8 +8,7 @@ pub struct DirectionalVolumeRatio {
     buy_volume: f64,
 }
 
-impl CandleComponent for DirectionalVolumeRatio {
-    type Output = f64;
+impl CandleComponent<f64> for DirectionalVolumeRatio {
     #[inline(always)]
     fn value(&self) -> f64 {
         self.buy_volume / self.volume

--- a/src/candle_components/directional_volume_ratio.rs
+++ b/src/candle_components/directional_volume_ratio.rs
@@ -9,6 +9,7 @@ pub struct DirectionalVolumeRatio {
 }
 
 impl CandleComponent for DirectionalVolumeRatio {
+    type Output = f64;
     #[inline(always)]
     fn value(&self) -> f64 {
         self.buy_volume / self.volume

--- a/src/candle_components/high.rs
+++ b/src/candle_components/high.rs
@@ -7,8 +7,7 @@ pub struct High {
     high: f64,
 }
 
-impl CandleComponent for High {
-    type Output = f64;
+impl CandleComponent<f64> for High {
     #[inline(always)]
     fn value(&self) -> f64 {
         self.high

--- a/src/candle_components/high.rs
+++ b/src/candle_components/high.rs
@@ -8,6 +8,7 @@ pub struct High {
 }
 
 impl CandleComponent for High {
+    type Output = f64;
     #[inline(always)]
     fn value(&self) -> f64 {
         self.high

--- a/src/candle_components/low.rs
+++ b/src/candle_components/low.rs
@@ -15,8 +15,7 @@ impl Default for Low {
     }
 }
 
-impl CandleComponent for Low {
-    type Output = f64;
+impl CandleComponent<f64> for Low {
     #[inline(always)]
     fn value(&self) -> f64 {
         self.low

--- a/src/candle_components/low.rs
+++ b/src/candle_components/low.rs
@@ -16,6 +16,7 @@ impl Default for Low {
 }
 
 impl CandleComponent for Low {
+    type Output = f64;
     #[inline(always)]
     fn value(&self) -> f64 {
         self.low

--- a/src/candle_components/median_price.rs
+++ b/src/candle_components/median_price.rs
@@ -8,6 +8,7 @@ pub struct MedianPrice {
 }
 
 impl CandleComponent for MedianPrice {
+    type Output = f64;
     #[inline(always)]
     fn value(&self) -> f64 {
         let mut prices = self.prices.clone();

--- a/src/candle_components/median_price.rs
+++ b/src/candle_components/median_price.rs
@@ -7,8 +7,7 @@ pub struct MedianPrice {
     prices: Vec<f64>,
 }
 
-impl CandleComponent for MedianPrice {
-    type Output = f64;
+impl CandleComponent<f64> for MedianPrice {
     #[inline(always)]
     fn value(&self) -> f64 {
         let mut prices = self.prices.clone();

--- a/src/candle_components/mod.rs
+++ b/src/candle_components/mod.rs
@@ -3,10 +3,7 @@
 
 mod average_price;
 mod candle_component_trait;
-#[cfg(feature = "chrono")]
-mod candle_datetime;
 mod close;
-mod date;
 mod directional_trade_ratio;
 mod directional_volume_ratio;
 mod high;
@@ -14,6 +11,9 @@ mod low;
 mod median_price;
 mod num_trades;
 mod open;
+#[cfg(feature = "chrono")]
+mod open_datetime;
+mod open_timestamp;
 mod std_dev_prices;
 mod std_dev_sizes;
 mod time_velocity;
@@ -22,10 +22,7 @@ mod weighted_price;
 
 pub use average_price::AveragePrice;
 pub use candle_component_trait::{CandleComponent, CandleComponentUpdate};
-#[cfg(feature = "chrono")]
-pub use candle_datetime::CandleDateTime;
 pub use close::Close;
-pub use date::TimeStamp;
 pub use directional_trade_ratio::DirectionalTradeRatio;
 pub use directional_volume_ratio::DirectionalVolumeRatio;
 pub use high::High;
@@ -33,6 +30,9 @@ pub use low::Low;
 pub use median_price::MedianPrice;
 pub use num_trades::NumTrades;
 pub use open::Open;
+#[cfg(feature = "chrono")]
+pub use open_datetime::OpenDateTime;
+pub use open_timestamp::OpenTimeStamp;
 pub use std_dev_prices::StdDevPrices;
 pub use std_dev_sizes::StdDevSizes;
 pub use time_velocity::TimeVelocity;

--- a/src/candle_components/mod.rs
+++ b/src/candle_components/mod.rs
@@ -45,7 +45,7 @@ mod tests {
 
     pub const TRADES: [Trade; 10] = [
         Trade {
-            timestamp: 0,
+            timestamp: 500000000000,
             price: 100.0,
             size: 10.0,
         },

--- a/src/candle_components/mod.rs
+++ b/src/candle_components/mod.rs
@@ -3,6 +3,8 @@
 
 mod average_price;
 mod candle_component_trait;
+#[cfg(feature = "chrono")]
+mod candle_datetime;
 mod close;
 mod date;
 mod directional_trade_ratio;
@@ -20,6 +22,8 @@ mod weighted_price;
 
 pub use average_price::AveragePrice;
 pub use candle_component_trait::{CandleComponent, CandleComponentUpdate};
+#[cfg(feature = "chrono")]
+pub use candle_datetime::CandleDateTime;
 pub use close::Close;
 pub use date::TimeStamp;
 pub use directional_trade_ratio::DirectionalTradeRatio;

--- a/src/candle_components/mod.rs
+++ b/src/candle_components/mod.rs
@@ -4,6 +4,7 @@
 mod average_price;
 mod candle_component_trait;
 mod close;
+mod date;
 mod directional_trade_ratio;
 mod directional_volume_ratio;
 mod high;
@@ -20,6 +21,7 @@ mod weighted_price;
 pub use average_price::AveragePrice;
 pub use candle_component_trait::{CandleComponent, CandleComponentUpdate};
 pub use close::Close;
+pub use date::TimeStamp;
 pub use directional_trade_ratio::DirectionalTradeRatio;
 pub use directional_volume_ratio::DirectionalVolumeRatio;
 pub use high::High;

--- a/src/candle_components/num_trades.rs
+++ b/src/candle_components/num_trades.rs
@@ -1,14 +1,16 @@
+use std::marker::PhantomData;
+
 use crate::{CandleComponent, CandleComponentUpdate, TakerTrade};
 
 /// This 'CandleComponent' keeps track of the number of trades
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NumTrades<T> {
-    value: T,
+    value: u32,
+    phantom: PhantomData<T>,
 }
 
-impl CandleComponent for NumTrades<u32> {
-    type Output = u32;
+impl CandleComponent<u32> for NumTrades<u32> {
     #[inline(always)]
     fn value(&self) -> u32 {
         self.value

--- a/src/candle_components/num_trades.rs
+++ b/src/candle_components/num_trades.rs
@@ -3,28 +3,26 @@ use crate::{CandleComponent, CandleComponentUpdate, TakerTrade};
 /// This 'CandleComponent' keeps track of the number of trades
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct NumTrades {
-    value: f64,
+pub struct NumTrades<T> {
+    value: T,
 }
 
-impl CandleComponent for NumTrades {
-    /// NOTE: this returns f64 out of convenience, but this trait could be made generic in the future
+impl CandleComponent for NumTrades<u32> {
+    type Output = u32;
     #[inline(always)]
-    fn value(&self) -> f64 {
+    fn value(&self) -> u32 {
         self.value
     }
 
     #[inline(always)]
     fn reset(&mut self) {
-        self.value = 0.0;
+        self.value = 0;
     }
 }
-impl<T: TakerTrade> CandleComponentUpdate<T> for NumTrades {
-    /// NOTE: this returns f64 out of convenience, but this trait could be made generic in the future
-
+impl<T: TakerTrade> CandleComponentUpdate<T> for NumTrades<u32> {
     #[inline(always)]
     fn update(&mut self, _: &T) {
-        self.value += 1.0;
+        self.value += 1;
     }
 }
 
@@ -38,6 +36,6 @@ mod tests {
         for t in &crate::candle_components::tests::TRADES {
             m.update(t);
         }
-        assert_eq!(m.value(), 10.0);
+        assert_eq!(m.value(), 10);
     }
 }

--- a/src/candle_components/num_trades.rs
+++ b/src/candle_components/num_trades.rs
@@ -1,13 +1,10 @@
-use std::marker::PhantomData;
-
 use crate::{CandleComponent, CandleComponentUpdate, TakerTrade};
 
 /// This 'CandleComponent' keeps track of the number of trades
 #[derive(Debug, Default, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct NumTrades<T> {
-    value: u32,
-    phantom: PhantomData<T>,
+    value: T,
 }
 
 impl CandleComponent<u32> for NumTrades<u32> {

--- a/src/candle_components/open.rs
+++ b/src/candle_components/open.rs
@@ -17,8 +17,7 @@ impl Default for Open {
     }
 }
 
-impl CandleComponent for Open {
-    type Output = f64;
+impl CandleComponent<f64> for Open {
     /// Returns the open price of the candle
     #[inline(always)]
     fn value(&self) -> f64 {

--- a/src/candle_components/open_datetime.rs
+++ b/src/candle_components/open_datetime.rs
@@ -1,14 +1,13 @@
-#![cfg(feature = "chrono")]
 use chrono::{DateTime, Utc};
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct CandleDateTime {
+pub struct OpenDateTime {
     init: bool,
     value: DateTime<Utc>,
 }
 
-impl CandleComponent<DateTime<Utc>> for CandleDateTime {
+impl CandleComponent<DateTime<Utc>> for OpenDateTime {
     /// Returns the open price of the candle
     #[inline(always)]
     fn value(&self) -> DateTime<Utc> {
@@ -21,7 +20,7 @@ impl CandleComponent<DateTime<Utc>> for CandleDateTime {
     }
 }
 
-impl<T: TakerTrade> CandleComponentUpdate<T> for CandleDateTime {
+impl<T: TakerTrade> CandleComponentUpdate<T> for OpenDateTime {
     /// Only update the open price if this module is in init mode
     #[inline(always)]
     fn update(&mut self, trade: &T) {

--- a/src/candle_components/open_datetime.rs
+++ b/src/candle_components/open_datetime.rs
@@ -12,6 +12,15 @@ pub struct OpenDateTime {
     value: DateTime<Utc>,
 }
 
+impl Default for OpenDateTime {
+    fn default() -> Self {
+        Self {
+            init: true,
+            value: Default::default(),
+        }
+    }
+}
+
 impl CandleComponent<DateTime<Utc>> for OpenDateTime {
     /// Returns the open price of the candle
     #[inline(always)]
@@ -39,5 +48,19 @@ impl<T: TakerTrade> CandleComponentUpdate<T> for OpenDateTime {
             };
             self.init = false;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_datetime() {
+        let mut m = OpenDateTime::default();
+        for t in &crate::candle_components::tests::TRADES {
+            m.update(t);
+        }
+        assert_eq!(m.value(), Utc.ymd(1985, 11, 5).and_hms(0, 53, 20));
     }
 }

--- a/src/candle_components/open_timestamp.rs
+++ b/src/candle_components/open_timestamp.rs
@@ -1,7 +1,7 @@
 use crate::{CandleComponent, CandleComponentUpdate, TakerTrade};
 
 /// This 'CandleComponent' keeps track of the opening timestamp of a Candle, using the
-/// milliseconds since UTC convention from the [TakerTrade] trait.
+/// same unit resolution as the underlying input of [TakerTrade.timestamp()].
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OpenTimeStamp<T> {

--- a/src/candle_components/open_timestamp.rs
+++ b/src/candle_components/open_timestamp.rs
@@ -1,14 +1,15 @@
 use crate::{CandleComponent, CandleComponentUpdate, TakerTrade};
 
-/// This 'CandleComponent' keeps track of the opening timestamp of a Candle
+/// This 'CandleComponent' keeps track of the opening timestamp of a Candle, using the
+/// milliseconds since UTC convention from the [TakerTrade] trait.
 #[derive(Debug, Clone, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct TimeStamp<T> {
+pub struct OpenTimeStamp<T> {
     init: bool,
     value: T,
 }
 
-impl CandleComponent<i64> for TimeStamp<i64> {
+impl CandleComponent<i64> for OpenTimeStamp<i64> {
     /// Returns the open price of the candle
     #[inline(always)]
     fn value(&self) -> i64 {
@@ -21,7 +22,7 @@ impl CandleComponent<i64> for TimeStamp<i64> {
     }
 }
 
-impl<T: TakerTrade> CandleComponentUpdate<T> for TimeStamp<i64> {
+impl<T: TakerTrade> CandleComponentUpdate<T> for OpenTimeStamp<i64> {
     /// Only update the open price if this module is in init mode
     #[inline(always)]
     fn update(&mut self, trade: &T) {

--- a/src/candle_components/open_timestamp.rs
+++ b/src/candle_components/open_timestamp.rs
@@ -2,11 +2,20 @@ use crate::{CandleComponent, CandleComponentUpdate, TakerTrade};
 
 /// This 'CandleComponent' keeps track of the opening timestamp of a Candle, using the
 /// same unit resolution as the underlying input of [TakerTrade.timestamp()].
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct OpenTimeStamp<T> {
     init: bool,
     value: T,
+}
+
+impl<T: Default> Default for OpenTimeStamp<T> {
+    fn default() -> Self {
+        Self {
+            init: true,
+            value: Default::default(),
+        }
+    }
 }
 
 impl CandleComponent<i64> for OpenTimeStamp<i64> {
@@ -30,5 +39,19 @@ impl<T: TakerTrade> CandleComponentUpdate<T> for OpenTimeStamp<i64> {
             self.value = trade.timestamp();
             self.init = false;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_timestamp() {
+        let mut m = OpenTimeStamp::default();
+        for t in &crate::candle_components::tests::TRADES {
+            m.update(t);
+        }
+        assert_eq!(m.value(), 500000000000);
     }
 }

--- a/src/candle_components/std_dev_prices.rs
+++ b/src/candle_components/std_dev_prices.rs
@@ -15,8 +15,7 @@ impl Default for StdDevPrices {
     }
 }
 
-impl CandleComponent for StdDevPrices {
-    type Output = f64;
+impl CandleComponent<f64> for StdDevPrices {
     #[inline(always)]
     fn value(&self) -> f64 {
         self.welford.std_dev()

--- a/src/candle_components/std_dev_prices.rs
+++ b/src/candle_components/std_dev_prices.rs
@@ -16,6 +16,7 @@ impl Default for StdDevPrices {
 }
 
 impl CandleComponent for StdDevPrices {
+    type Output = f64;
     #[inline(always)]
     fn value(&self) -> f64 {
         self.welford.std_dev()

--- a/src/candle_components/std_dev_sizes.rs
+++ b/src/candle_components/std_dev_sizes.rs
@@ -15,6 +15,7 @@ impl Default for StdDevSizes {
     }
 }
 impl CandleComponent for StdDevSizes {
+    type Output = f64;
     #[inline(always)]
     fn value(&self) -> f64 {
         self.welford.std_dev()

--- a/src/candle_components/std_dev_sizes.rs
+++ b/src/candle_components/std_dev_sizes.rs
@@ -14,8 +14,7 @@ impl Default for StdDevSizes {
         }
     }
 }
-impl CandleComponent for StdDevSizes {
-    type Output = f64;
+impl CandleComponent<f64> for StdDevSizes {
     #[inline(always)]
     fn value(&self) -> f64 {
         self.welford.std_dev()

--- a/src/candle_components/time_velocity.rs
+++ b/src/candle_components/time_velocity.rs
@@ -23,6 +23,7 @@ impl Default for TimeVelocity {
 }
 
 impl CandleComponent for TimeVelocity {
+    type Output = f64;
     #[inline(always)]
     fn value(&self) -> f64 {
         let mut elapsed_s: f64 = (self.last_time - self.init_time) as f64 / 1000.0;

--- a/src/candle_components/time_velocity.rs
+++ b/src/candle_components/time_velocity.rs
@@ -22,8 +22,7 @@ impl Default for TimeVelocity {
     }
 }
 
-impl CandleComponent for TimeVelocity {
-    type Output = f64;
+impl CandleComponent<f64> for TimeVelocity {
     #[inline(always)]
     fn value(&self) -> f64 {
         let mut elapsed_s: f64 = (self.last_time - self.init_time) as f64 / 1000.0;

--- a/src/candle_components/volume.rs
+++ b/src/candle_components/volume.rs
@@ -8,6 +8,7 @@ pub struct Volume {
 }
 
 impl CandleComponent for Volume {
+    type Output = f64;
     #[inline(always)]
     fn value(&self) -> f64 {
         self.volume

--- a/src/candle_components/volume.rs
+++ b/src/candle_components/volume.rs
@@ -7,8 +7,7 @@ pub struct Volume {
     volume: f64,
 }
 
-impl CandleComponent for Volume {
-    type Output = f64;
+impl CandleComponent<f64> for Volume {
     #[inline(always)]
     fn value(&self) -> f64 {
         self.volume

--- a/src/candle_components/weighted_price.rs
+++ b/src/candle_components/weighted_price.rs
@@ -9,6 +9,7 @@ pub struct WeightedPrice {
 }
 
 impl CandleComponent for WeightedPrice {
+    type Output = f64;
     #[inline(always)]
     fn value(&self) -> f64 {
         self.weighted_sum / self.total_weights

--- a/src/candle_components/weighted_price.rs
+++ b/src/candle_components/weighted_price.rs
@@ -8,8 +8,7 @@ pub struct WeightedPrice {
     weighted_sum: f64,
 }
 
-impl CandleComponent for WeightedPrice {
-    type Output = f64;
+impl CandleComponent<f64> for WeightedPrice {
     #[inline(always)]
     fn value(&self) -> f64 {
         self.weighted_sum / self.total_weights

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,3 +1,5 @@
+use crate::TimestampResolution;
+
 #[derive(Default, Debug, Clone, Copy)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 /// Defines a taker trade
@@ -47,8 +49,13 @@ pub enum By {
 /// Trait to enable third party types to be passed into aggregators.
 pub trait TakerTrade {
     /// The timestamp of a trade,
-    /// For the built in time rule, this is expected to be in milliseconds
     fn timestamp(&self) -> i64;
+
+    /// units for the timestamp integer returned by [TakerTrade.timestamp()] method
+    /// A default implementation is included and assumes milliseconds
+    fn timestamp_resolution(&self) -> TimestampResolution {
+        TimestampResolution::Millisecond
+    }
 
     /// Fill price of the transaction
     fn price(&self) -> f64;

--- a/trade_aggregation_derive/src/lib.rs
+++ b/trade_aggregation_derive/src/lib.rs
@@ -96,35 +96,11 @@ fn impl_candle_macro(ast: &syn::DeriveInput) -> TokenStream {
         }
     }
 
-    // input defaults to [Trade], but can be a custom user type as well, see
-    // [MyCandle] in user_trade_type.rs
-    // let input_field = components
-    //     .iter()
-    //     .map(|x| x)
-    //     .filter(|x| format!("{}", x.ident.clone().unwrap()) == "input")
-    //     .next();
-    // let input_type = match input_field {
-    //     Some(syn::Field {
-    //         ty: syn::Type::Path(syn::TypePath { path: p, .. }),
-    //         ..
-    //     }) => phantom_path_to_type(&p),
-    //     None => Some(Ident::new("Trade", Span::call_site())),
-    //     _ => panic!("input attribute is expected to be PhantomData<Input>"),
-    // };
-
-    // let fn_names0 = components
-    //     .iter()
-    //     .filter(|v| format!("{}", v.ident.clone().unwrap()) != "input")
-    //     .map(|v| v.ident.clone().unwrap());
-
     let fn_names0 = value_idents.clone();
     let fn_names1 = fn_names0.clone();
     let fn_names2 = fn_names1.clone();
     let input_name = input_type.expect("No PhantomData for input attribute type!");
     println!("impl building for {name}");
-    // for name in fn_names1.clone() {
-    //     println!("\t\t{name}");
-    // }
 
     let gen = quote! {
         impl #name {


### PR DESCRIPTION
Hi Mathis,

Wondering what you think of this?  I needed a non-f64 attribute on one of my Candles (specifically `Datetime`) and that was my inspiration.  It really applies to any indicator though, you may want to have a type that is not `f64` as your response to `value()`, such as with `TradeCount` is really an integer not a float, or maybe an `enum` as a state machine or something.  Maybe its more complexity than its worth not sure.  Let me know what you think.

Cheers, 
Dave