### PR TITLE
Re-enable aggregate_all_trades test

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ impl ModularCandle<Trade> for MyCandle {
 
 See examples folder for more.
 Run examples using
-```ignore
+```sh,ignore
 cargo run --release --example aggregate_all_ohlc
 cargo run --release --example streaming_aggregate_ohlc
 ```
@@ -163,7 +163,7 @@ cargo run --release --example streaming_aggregate_ohlc
 ## Performance:
 To run the benchmarks, written using criterion, run:
 
-```ignore
+```sh,ignore
 cargo bench
 ```
 


### PR DESCRIPTION
I noticed that there was a commented out test with a `TODO` in it to re-enable. I set a `ignore` flag in order to run it manually as I'm assuming it'd be desirable to run it only in specific cases since reading the raw data file might not be what is intended each time we run the tests. I see, however, that there are tests using the raw data file elsewhere, so ignoring it only here might not be consistent to the codebase.

