### PR TITLE
feat: add unfinished_candle method

### DIFF
--- a/src/aggregator.rs
+++ b/src/aggregator.rs
@@ -13,6 +13,11 @@ pub trait Aggregator<Candle, T: TakerTrade> {
     /// Some output only when a new candle has been created,
     /// otherwise it returns None
     fn update(&mut self, trade: &T) -> Option<Candle>;
+
+    /// Get a reference to an unfinished `Candle`.
+    /// Accessing a `Candle` using this method does not guarantee that the `AggregationRule` is respected.
+    /// It is generally advised to call `update` instead and use the resulting `Candle` if its `Some`.
+    fn unfinished_candle(&self) -> &Candle;
 }
 
 /// An `Aggregator` that is generic over
@@ -63,6 +68,10 @@ where
 
         self.candle.update(trade);
         None
+    }
+
+    fn unfinished_candle(&self) -> &C {
+        &self.candle
     }
 }
 


### PR DESCRIPTION
Another problem I have faced, is that there is no way to get the latest candle from the aggregator.

Input data:

```
timestamp,price,size
1612137602564000,27334.25,0.00289
1612137664747000,27298.5,0.00909044
```

`TimeRule` and `AlignedTimeRule` will trigger on a first trade, and will return the candle, but there is no way to get the second candle. 

I propose to add a new state for candle - `finalized`, and method `close` to aggregator. This way, user can easily retrieve the latest candle from the aggregator. 

Let me know if there are other ways to achieve this. 