### PR TITLE
Generic Agg will take a candle factory rather than rely on Default

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To use this crate in your project, add the following to your Cargo.toml:
 
 ```toml
 [dependencies]
-trade_aggregation = "12"
+trade_aggregation = "13"
 ```
 
 Lets aggregate all trades into time based 1 minute candles, consisting of open, high, low and close information.
@@ -87,7 +87,7 @@ fn main() {
     let time_rule = TimeRule::new(M1, TimestampResolution::Millisecond);
     // Notice how the aggregator is generic over the output candle type, 
     // the aggregation rule as well as the input trade data
-    let mut aggregator = GenericAggregator::<MyCandle, TimeRule, Trade>::new(time_rule, false);
+    let mut aggregator = GenericAggregator::<MyCandle, TimeRule, Trade>::new(time_rule, false, MyCandle::default);
 
     for t in &trades {
         if let Some(candle) = aggregator.update(t) {

--- a/benches/candle_aggregation.rs
+++ b/benches/candle_aggregation.rs
@@ -37,19 +37,28 @@ struct CandleAll {
 
 fn time_aggregation_open(trades: &[Trade]) {
     let time_rule = TimeRule::new(M1, TimestampResolution::Millisecond);
-    let mut aggregator = GenericAggregator::<CandleOpen, TimeRule, Trade>::new(time_rule, false);
+    let mut aggregator = GenericAggregator::<CandleOpen, TimeRule, Trade>::new(
+        time_rule,
+        false,
+        CandleOpen::default,
+    );
     let _candles = aggregate_all_trades(trades, &mut aggregator);
 }
 
 fn time_aggregation_ohlc(trades: &[Trade]) {
     let time_rule = TimeRule::new(M1, TimestampResolution::Millisecond);
-    let mut aggregator = GenericAggregator::<CandleOHLC, TimeRule, Trade>::new(time_rule, false);
+    let mut aggregator = GenericAggregator::<CandleOHLC, TimeRule, Trade>::new(
+        time_rule,
+        false,
+        CandleOHLC::default,
+    );
     let _candles = aggregate_all_trades(trades, &mut aggregator);
 }
 
 fn time_aggregation_all(trades: &[Trade]) {
     let time_rule = TimeRule::new(M1, TimestampResolution::Millisecond);
-    let mut aggregator = GenericAggregator::<CandleAll, TimeRule, Trade>::new(time_rule, false);
+    let mut aggregator =
+        GenericAggregator::<CandleAll, TimeRule, Trade>::new(time_rule, false, CandleAll::default);
     let _candles = aggregate_all_trades(trades, &mut aggregator);
 }
 

--- a/examples/aggregate_all_ohlc.rs
+++ b/examples/aggregate_all_ohlc.rs
@@ -25,7 +25,8 @@ fn main() {
 
     // specify the aggregation rule to be time based
     let time_rule = TimeRule::new(M1, TimestampResolution::Millisecond);
-    let mut aggregator = GenericAggregator::<MyCandle, TimeRule, Trade>::new(time_rule, false);
+    let mut aggregator =
+        GenericAggregator::<MyCandle, TimeRule, Trade>::new(time_rule, false, MyCandle::default);
 
     let candles = aggregate_all_trades(&trades, &mut aggregator);
     println!("got {} candles", candles.len());

--- a/examples/streaming_aggregate_ohlc.rs
+++ b/examples/streaming_aggregate_ohlc.rs
@@ -20,7 +20,8 @@ fn main() {
 
     // specify the aggregation rule to be time based
     let time_rule = TimeRule::new(M1, TimestampResolution::Millisecond);
-    let mut aggregator = GenericAggregator::<MyCandle, TimeRule, Trade>::new(time_rule, false);
+    let mut aggregator =
+        GenericAggregator::<MyCandle, TimeRule, Trade>::new(time_rule, false, MyCandle::default);
 
     for t in &trades {
         if let Some(candle) = aggregator.update(t) {

--- a/examples/user_trade_type.rs
+++ b/examples/user_trade_type.rs
@@ -88,7 +88,8 @@ fn main() {
 
     // specify the aggregation rule to be time based
     let time_rule = TimeRule::new(M1, TimestampResolution::Millisecond);
-    let mut aggregator = GenericAggregator::<MyCandle, TimeRule, Tick>::new(time_rule, false);
+    let mut aggregator =
+        GenericAggregator::<MyCandle, TimeRule, Tick>::new(time_rule, false, MyCandle::default);
 
     let candles = aggregate_all_trades(&ticks, &mut aggregator);
     println!("got {} candles", candles.len());

--- a/src/aggregation_rules/aligned_time_rule.rs
+++ b/src/aggregation_rules/aligned_time_rule.rs
@@ -105,6 +105,7 @@ mod tests {
         let mut aggregator = GenericAggregator::<MyCandle, AlignedTimeRule, Trade>::new(
             AlignedTimeRule::new(M15, TimestampResolution::Millisecond),
             false,
+            MyCandle::default,
         );
         let candles = aggregate_all_trades(&trades, &mut aggregator);
         assert_eq!(candles.len(), 396);
@@ -126,6 +127,7 @@ mod tests {
         let mut aggregator = GenericAggregator::<MyCandle, AlignedTimeRule, Trade>::new(
             AlignedTimeRule::new(M1, TimestampResolution::Microsecond),
             false,
+            MyCandle::default,
         );
         let candles = aggregate_all_trades(&trades, &mut aggregator);
 
@@ -167,6 +169,7 @@ mod tests {
         let mut aggregator = GenericAggregator::<OhlcCandle, AlignedTimeRule, Trade>::new(
             AlignedTimeRule::new(M1, TimestampResolution::Millisecond),
             false,
+            OhlcCandle::default,
         );
         let candles = aggregate_all_trades(&trades, &mut aggregator);
         assert_eq!(candles.len(), 2);
@@ -204,6 +207,7 @@ mod tests {
         let mut aggregator = GenericAggregator::<OhlcCandle, AlignedTimeRule, Trade>::new(
             AlignedTimeRule::new(M1, TimestampResolution::Millisecond),
             false,
+            OhlcCandle::default,
         );
         let candles = aggregate_all_trades(&trades, &mut aggregator);
         assert_eq!(candles.len(), 2);

--- a/src/aggregation_rules/relative_price_rule.rs
+++ b/src/aggregation_rules/relative_price_rule.rs
@@ -125,7 +125,8 @@ mod tests {
         // 0.5% candles
         const THRESHOLD: f64 = 0.005;
         let rule = RelativePriceRule::new(0.01).unwrap();
-        let mut aggregator = GenericAggregator::<OhlcCandle, _, Trade>::new(rule, false);
+        let mut aggregator =
+            GenericAggregator::<OhlcCandle, _, Trade>::new(rule, false, OhlcCandle::default);
         let candles = aggregate_all_trades(&trades, &mut aggregator);
         assert!(!candles.is_empty());
 
@@ -141,7 +142,8 @@ mod tests {
 
         const THRESHOLD: f64 = 0.005;
         let rule = RelativePriceRule::new(THRESHOLD).unwrap();
-        let mut aggregator = GenericAggregator::<OhlcCandle, _, Trade>::new(rule, false);
+        let mut aggregator =
+            GenericAggregator::<OhlcCandle, _, Trade>::new(rule, false, OhlcCandle::default);
         let candles = aggregate_all_trades(&trades, &mut aggregator);
         println!("got {} candles", candles.len());
 

--- a/src/aggregation_rules/tick_rule.rs
+++ b/src/aggregation_rules/tick_rule.rs
@@ -55,8 +55,11 @@ mod tests {
     fn tick_rule() {
         let trades = load_trades_from_csv("data/Bitmex_XBTUSD_1M.csv").unwrap();
 
-        let mut aggregator =
-            GenericAggregator::<OhlcCandle, TickRule, Trade>::new(TickRule::new(1000), false);
+        let mut aggregator = GenericAggregator::<OhlcCandle, TickRule, Trade>::new(
+            TickRule::new(1000),
+            false,
+            OhlcCandle::default,
+        );
         let candles = aggregate_all_trades(&trades, &mut aggregator);
         // As there are 1 million trades in the test data, this will create 1000 candles
         assert_eq!(candles.len(), 1000);

--- a/src/aggregation_rules/time_rule.rs
+++ b/src/aggregation_rules/time_rule.rs
@@ -78,6 +78,7 @@ mod tests {
         let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(
             TimeRule::new(M15, TimestampResolution::Millisecond),
             false,
+            OhlcCandle::default,
         );
         let candles = aggregate_all_trades(&trades, &mut aggregator);
         println!("got {} candles", candles.len());
@@ -92,6 +93,7 @@ mod tests {
         let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(
             TimeRule::new(M15, TimestampResolution::Millisecond),
             false,
+            OhlcCandle::default,
         );
         let candles = aggregate_all_trades(&trades, &mut aggregator);
         assert_eq!(candles.len(), 396);
@@ -99,6 +101,7 @@ mod tests {
         let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(
             TimeRule::new(M5, TimestampResolution::Millisecond),
             false,
+            OhlcCandle::default,
         );
         let candles = aggregate_all_trades(&trades, &mut aggregator);
         assert_eq!(candles.len(), 1190);
@@ -106,6 +109,7 @@ mod tests {
         let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(
             TimeRule::new(H1, TimestampResolution::Millisecond),
             false,
+            OhlcCandle::default,
         );
         let candles = aggregate_all_trades(&trades, &mut aggregator);
         assert_eq!(candles.len(), 99);
@@ -138,6 +142,7 @@ mod tests {
         let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(
             TimeRule::new(M15, TimestampResolution::Millisecond),
             false,
+            OhlcCandle::default,
         );
         let candles = aggregate_all_trades(&trades_ms, &mut aggregator);
         assert_eq!(candles.len(), 396);
@@ -145,6 +150,7 @@ mod tests {
         let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(
             TimeRule::new(M15, TimestampResolution::Microsecond),
             false,
+            OhlcCandle::default,
         );
         let candles = aggregate_all_trades(&trades_micros, &mut aggregator);
         assert_eq!(candles.len(), 396);
@@ -152,6 +158,7 @@ mod tests {
         let mut aggregator = GenericAggregator::<OhlcCandle, TimeRule, Trade>::new(
             TimeRule::new(M15, TimestampResolution::Nanosecond),
             false,
+            OhlcCandle::default,
         );
         let candles = aggregate_all_trades(&trades_ns, &mut aggregator);
         assert_eq!(candles.len(), 396);

--- a/src/modular_candle_trait.rs
+++ b/src/modular_candle_trait.rs
@@ -3,7 +3,7 @@ use crate::TakerTrade;
 /// A modular candle that can be composed of multiple components
 /// Is generic over the type of trade it accepts during the update step,
 /// as long as it implements the `TakerTrade` trait
-pub trait ModularCandle<T: TakerTrade>: Clone + Default {
+pub trait ModularCandle<T: TakerTrade>: Clone {
     /// Updates the candle information with trade information
     fn update(&mut self, trade: &T);
 


### PR DESCRIPTION
This adds more flexibility in the types we can aggregate in case we need runtime parameters as part of that logic.

## Changes:


* 🦚 Feature


## References:


## Changes proposed by this PR:

Removed the trait bound for `Default` on the generic aggregators candle type, instead the `new(...)` method will take a zero argument closure.

## 📜 Checklist

* [x] The PR scope is bounded
* [x] Relevant issues and discussions are referenced
* [x] Test coverage is excellent and passes
* [x] Tests test the desired behavior
* [x] Documentation is thorough

